### PR TITLE
Fix for uninitialized variable in drift correction code

### DIFF
--- a/XIAO Firmware/code.py
+++ b/XIAO Firmware/code.py
@@ -144,6 +144,9 @@ if t.tm_year == 0:
     t = time.struct_time((2021, 5, 20, 20, 4, 30, 0, -1, -1))
     rtc.datetime = t
 
+# initialise the fixed time on day variable
+FIXED_TIME_ON_tm_mday = t.tm_mday
+
 # States
 main_state = MAIN_TIME
 menu_state = MENU_12_24


### PR DESCRIPTION
The FIXED_TIME_ON_tm_mday variable was not initialized before it is compared the first time, this results in the code failing with an exception. Initialized it to the init value used for the RTC. Maybe another approach here would be better but this seems to work well (it does mean the first night's drift correction will not occur).